### PR TITLE
CAnEnMPI dealing with excessive processes

### DIFF
--- a/CAnEnMPI/AnEnISMPI.cpp
+++ b/CAnEnMPI/AnEnISMPI.cpp
@@ -37,18 +37,7 @@ AnEnISMPI::compute(const Forecasts & forecasts, const Observations & observation
     // Get the process ID and the number of worker processes
     int world_rank, num_procs, num_workers;
     MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-
-    // Deal with the situation when the number of processes is greater than the number of stations plus 1
-    auto num_stations = forecasts.getStations().size();
-    if (num_procs > num_stations + 1) {
-        if (world_rank == 0 && verbose_ >= Verbose::Warning) {
-            cerr << "Warning: There are only " << num_stations << " stations but " << num_procs << " processes are created."
-                << "Only " << num_stations + 1 << " processes will be actually working!" << endl;
-        }
-
-        num_procs = num_stations + 1;
-    }
+    FunctionsMPI::effective_num_procs(MPI_COMM_WORLD, &num_procs, world_rank, forecasts, verbose_);
 
     // The number of workers is the number of processes minus 1 because process #0 is the master
     num_workers = num_procs - 1;
@@ -109,7 +98,7 @@ AnEnISMPI::compute(const Forecasts & forecasts, const Observations & observation
 
         profiler_.log_time_session("Master preprocessing (AnEnISMPI)");
 
-    } else {
+    } else if (world_rank < num_procs) {
         // This is a worker
 
 #if defined(_OPENMP)
@@ -138,6 +127,8 @@ AnEnISMPI::compute(const Forecasts & forecasts, const Observations & observation
         omp_set_dynamic(max_dynamic);
         omp_set_num_threads(max_threads);
 #endif
+    } else {
+        if (verbose_ >= Verbose::Debug) cout << "Worker #" << world_rank << " is doing nothing because too many process have been created!" << endl;
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
@@ -175,14 +166,19 @@ void
 AnEnISMPI::computeSds_(const Forecasts & forecasts, const vector<size_t> & times_fixed_index, const vector<size_t> & times_accum_index) {
 
     // Get the process ID and the number of worker processes
-    int world_rank;
+    int world_rank, num_procs;
     MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    FunctionsMPI::effective_num_procs(MPI_COMM_WORLD, &num_procs, world_rank, forecasts, verbose_);
 
     if (world_rank == 0) {
         if (verbose_ >= Verbose::Detail) cout << "Master process only allocate memory for standard deviation ..." << endl;
         AnEnIS::allocateSds_(forecasts, times_fixed_index, times_accum_index);
-    } else {
+
+    } else if (world_rank < num_procs) {
         AnEnIS::computeSds_(forecasts, times_fixed_index, times_accum_index);
+
+    } else {
+        if (verbose_ >= Verbose::Debug) cout << "Worker #" << world_rank << " is doing nothing because too many process have been created!" << endl;
     }
 
     return;

--- a/CAnEnMPI/AnEnISMPI.cpp
+++ b/CAnEnMPI/AnEnISMPI.cpp
@@ -39,6 +39,17 @@ AnEnISMPI::compute(const Forecasts & forecasts, const Observations & observation
     MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
 
+    // Deal with the situation when the number of processes is greater than the number of stations plus 1
+    auto num_stations = forecasts.getStations().size();
+    if (num_procs > num_stations + 1) {
+        if (world_rank == 0 && verbose_ >= Verbose::Warning) {
+            cerr << "Warning: There are only " << num_stations << " stations but " << num_procs << " processes are created."
+                << "Only " << num_stations + 1 << " processes will be actually working!" << endl;
+        }
+
+        num_procs = num_stations + 1;
+    }
+
     // The number of workers is the number of processes minus 1 because process #0 is the master
     num_workers = num_procs - 1;
 

--- a/CAnEnMPI/FunctionsMPI.cpp
+++ b/CAnEnMPI/FunctionsMPI.cpp
@@ -30,7 +30,7 @@ FunctionsMPI::effective_num_procs(MPI_Comm comm, int *num_procs, int world_rank,
         size_t num_stations = forecasts.getStations().size();
 
         if (*num_procs > num_stations + 1) {
-            if (world_rank == 0 && verbose >= Verbose::Warning) {
+            if (verbose >= Verbose::Warning) {
                 cerr << "Warning: There are only " << num_stations << " stations but " << *num_procs << " processes are created."
                     << "Only " << num_stations + 1 << " processes will be effectively working" << endl;
             }

--- a/CAnEnMPI/FunctionsMPI.h
+++ b/CAnEnMPI/FunctionsMPI.h
@@ -10,6 +10,7 @@
 #define FUNCTIONSMPI_H
 
 #include <vector>
+#include <mpi.h>
 
 #include "AnEnIS.h"
 #include "Forecasts.h"
@@ -17,6 +18,7 @@
 
 namespace FunctionsMPI {
 
+    void effective_num_procs(MPI_Comm comm, int *num_procs, int world_rank, const Forecasts & forecasts, Verbose verbose);
     void scatterObservations(const Observations & send, Observations & recv, int num_procs, int rank, Verbose verbose);
     void scatterForecasts(const Forecasts & send, Forecasts & recv, int num_procs, int rank, Verbose verbose);
     void scatterBasicData(const BasicData & send, BasicData & recv, int num_procs, int rank, Verbose verbose);

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # PAnEn 4.2.7
 
 - Added test time specification to C++ utility tools
+- Added functionality to `CAnEnMPI` to deal with excessive processes
 
 # PAnEn 4.2.6
 


### PR DESCRIPTION
In this pull request, the new functionality is added to CAnEnMPI. The number of processes is decided not only based on the size of the communication world, but also based on the number of stations to be parallelized. When there are too many processes and too few stations, extra processes will not be allocated with any workload.

Previously, this situation will lead to a critical fault.